### PR TITLE
- When TextractDocument is created from blocks, the operation can tak…

### DIFF
--- a/src-csharp/TextractExtensions/Cell.cs
+++ b/src-csharp/TextractExtensions/Cell.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Amazon.Textract.Model;
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 	public class Cell {
 		public Cell(Block block, Dictionary<string, Block> blocks) {
             if(block == null)

--- a/src-csharp/TextractExtensions/Cell.cs
+++ b/src-csharp/TextractExtensions/Cell.cs
@@ -1,8 +1,11 @@
 using System.Collections.Generic;
+using Amazon.Textract.Model;
 
-namespace Amazon.Textract.Model {
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 	public class Cell {
-		public Cell(Block block, List<Block> blocks) {
+		public Cell(Block block, Dictionary<string, Block> blocks) {
+            if(block == null)
+                return;
 			this.Block = block;
 			this.ColumnIndex = block.ColumnIndex;
 			this.ColumnSpan = block.ColumnSpan;
@@ -19,12 +22,12 @@ namespace Amazon.Textract.Model {
 				relationships.ForEach(r => {
 					if(r.Type == "CHILD") {
 						r.Ids.ForEach(id => {
-							var rb = blocks.Find(b => b.Id == id);
-							if(rb.BlockType == "WORD") {
+							var rb = blocks[id];
+                            if(rb != null && rb.BlockType == "WORD") {
 								var w = new Word(rb, blocks);
 								this.Content.Add(w);
 								this.Text = this.Text + w.Text + " ";
-							} else if(rb.BlockType == "SELECTION_ELEMENT") {
+							} else if(rb != null && rb.BlockType == "SELECTION_ELEMENT") {
 								var se = new SelectionElement(rb, blocks);
 								this.Content.Add(se);
 								this.Text = this.Text + se.SelectionStatus + ", ";

--- a/src-csharp/TextractExtensions/Field.cs
+++ b/src-csharp/TextractExtensions/Field.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
+using Amazon.Textract.Model;
 
-namespace Amazon.Textract.Model {
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 
 	public class Field {
-		public Field(Block block, List<Block> blocks) {
+		public Field(Block block, Dictionary<string, Block> blocks) {
 			var relationships = block.Relationships;
 			if(relationships != null && relationships.Count > 0) {
 				relationships.ForEach(r => {
@@ -12,7 +13,7 @@ namespace Amazon.Textract.Model {
 						this.Key = new FieldKey(block, r.Ids, blocks);
 					} else if(r.Type == "VALUE") {
 						r.Ids.ForEach(id => {
-							var v = blocks.Find(b => b.Id == id);
+							var v = blocks[id];
 							if(v.EntityTypes.Contains("VALUE")) {
 								var vr = v.Relationships;
 								if(vr != null && vr.Count > 0) {

--- a/src-csharp/TextractExtensions/Field.cs
+++ b/src-csharp/TextractExtensions/Field.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using Amazon.Textract.Model;
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 
 	public class Field {
 		public Field(Block block, Dictionary<string, Block> blocks) {

--- a/src-csharp/TextractExtensions/FieldKey.cs
+++ b/src-csharp/TextractExtensions/FieldKey.cs
@@ -53,7 +53,7 @@ class FieldKey:
 using System.Collections.Generic;
 using Amazon.Textract.Model;
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 	public class FieldKey {
 		public FieldKey(Block block, List<string> children, Dictionary<string, Block> blocks) {
 			this.Block = block;

--- a/src-csharp/TextractExtensions/FieldKey.cs
+++ b/src-csharp/TextractExtensions/FieldKey.cs
@@ -51,10 +51,11 @@ class FieldKey:
  */
 
 using System.Collections.Generic;
+using Amazon.Textract.Model;
 
-namespace Amazon.Textract.Model {
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 	public class FieldKey {
-		public FieldKey(Block block, List<string> children, List<Block> blocks) {
+		public FieldKey(Block block, List<string> children, Dictionary<string, Block> blocks) {
 			this.Block = block;
 			this.Confidence = block.Confidence;
 			this.Geometry = block.Geometry;
@@ -66,7 +67,7 @@ namespace Amazon.Textract.Model {
 
 			if(children != null && children.Count > 0) {
 				children.ForEach(c => {
-					var wordBlock = blocks.Find(b => b.Id == c);
+					var wordBlock = blocks[c];
 					if(wordBlock.BlockType == "WORD") {
 						var w = new Word(wordBlock, blocks);
 						this.Content.Add(w);

--- a/src-csharp/TextractExtensions/FieldValue.cs
+++ b/src-csharp/TextractExtensions/FieldValue.cs
@@ -59,7 +59,7 @@ class FieldValue:
 using System.Collections.Generic;
 using Amazon.Textract.Model;
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 	public class FieldValue {
 		public FieldValue(Block block, List<string> children, Dictionary<string, Block> blocks) {
 			this.Block = block;

--- a/src-csharp/TextractExtensions/FieldValue.cs
+++ b/src-csharp/TextractExtensions/FieldValue.cs
@@ -57,10 +57,11 @@ class FieldValue:
  */
 
 using System.Collections.Generic;
+using Amazon.Textract.Model;
 
-namespace Amazon.Textract.Model {
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 	public class FieldValue {
-		public FieldValue(Block block, List<string> children, List<Block> blocks) {
+		public FieldValue(Block block, List<string> children, Dictionary<string, Block> blocks) {
 			this.Block = block;
 			this.Confidence = block.Confidence;
 			this.Geometry = block.Geometry;
@@ -71,7 +72,7 @@ namespace Amazon.Textract.Model {
 			var words = new List<string>();
 			if(children != null && children.Count > 0) {
 				children.ForEach(c => {
-					var wordBlock = blocks.Find(b => b.Id == c);
+					var wordBlock = blocks[c];
 					if(wordBlock.BlockType == "WORD") {
 						var w = new Word(wordBlock, blocks);
 						this.Content.Add(w);

--- a/src-csharp/TextractExtensions/Form.cs
+++ b/src-csharp/TextractExtensions/Form.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 
 	public class Form {
 		public List<Field> Fields { get; set; }

--- a/src-csharp/TextractExtensions/Form.cs
+++ b/src-csharp/TextractExtensions/Form.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Amazon.Textract.Model {
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 
 	public class Form {
 		public List<Field> Fields { get; set; }
@@ -15,9 +15,9 @@ namespace Amazon.Textract.Model {
 			this.Fields.Add(field);
 			this.fieldMap.Add(field.Key.ToString(), field);
 		}
-		public Field GetFieldByKey(string key) {
-			return this.fieldMap.GetValueOrDefault(key);
-		}
+		//public Field GetFieldByKey(string key) {
+		//	return this.fieldMap.GetValueOrDefault(key);
+		//}
 
 		public List<Field> SearchFieldsByKey(string key) {
 			return this.Fields.FindAll(f => f.Key.ToString().ToLower().Contains(key.ToLower()));

--- a/src-csharp/TextractExtensions/Line.cs
+++ b/src-csharp/TextractExtensions/Line.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using Amazon.Textract.Model;
+
 /*
 class Line:
     def __init__(self, block, blockMap):
@@ -52,11 +55,9 @@ class Line:
         return self._block
  */
 
-using System.Collections.Generic;
-
-namespace Amazon.Textract.Model {
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 	public class Line {
-		public Line(Block block, List<Block> blocks) {
+		public Line(Block block, Dictionary<string, Block> blocks) {
 			this.Block = block;
 			this.Confidence = block.Confidence;
 			this.Geometry = block.Geometry;
@@ -69,8 +70,12 @@ namespace Amazon.Textract.Model {
 				relationships.ForEach(r => {
 					if(r.Type == "CHILD") {
 						r.Ids.ForEach(id => {
-							this.Words.Add(new Word(blocks.Find(b => b.BlockType == "WORD" && b.Id == id), blocks));
-						});
+                            var block = blocks[id];
+                            if(block.BlockType == "WORD")
+                                this.Words.Add(new Word(block, blocks));
+                            else
+                                this.Words.Add(new Word(null, blocks));
+                        });
 					}
 				});
 			}

--- a/src-csharp/TextractExtensions/Line.cs
+++ b/src-csharp/TextractExtensions/Line.cs
@@ -55,7 +55,7 @@ class Line:
         return self._block
  */
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 	public class Line {
 		public Line(Block block, Dictionary<string, Block> blocks) {
 			this.Block = block;

--- a/src-csharp/TextractExtensions/NewBoundingBox.cs
+++ b/src-csharp/TextractExtensions/NewBoundingBox.cs
@@ -1,6 +1,6 @@
 using Amazon.Textract.Model;
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 	public class NewBoundingBox : BoundingBox {
 		public NewBoundingBox(float width, float height, float left, float top) : base() {
 			this.Width = width;

--- a/src-csharp/TextractExtensions/NewBoundingBox.cs
+++ b/src-csharp/TextractExtensions/NewBoundingBox.cs
@@ -1,4 +1,6 @@
-namespace Amazon.Textract.Model {
+using Amazon.Textract.Model;
+
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 	public class NewBoundingBox : BoundingBox {
 		public NewBoundingBox(float width, float height, float left, float top) : base() {
 			this.Width = width;

--- a/src-csharp/TextractExtensions/NewGeometry.cs
+++ b/src-csharp/TextractExtensions/NewGeometry.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Amazon.Textract.Model;
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 	public class NewGeometry : Geometry {
 
 		public NewGeometry(Geometry geometry) : base() {

--- a/src-csharp/TextractExtensions/NewGeometry.cs
+++ b/src-csharp/TextractExtensions/NewGeometry.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using Amazon.Textract.Model;
 
-namespace Amazon.Textract.Model {
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 	public class NewGeometry : Geometry {
 
 		public NewGeometry(Geometry geometry) : base() {

--- a/src-csharp/TextractExtensions/Page.cs
+++ b/src-csharp/TextractExtensions/Page.cs
@@ -1,11 +1,11 @@
-using System.Dynamic;
 using System;
 using System.Collections.Generic;
+using Amazon.Textract.Model;
 
-namespace Amazon.Textract.Model {
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 
 	public class Page {
-		public Page(List<Block> blocks, List<Block> blockMap) {
+		public Page(List<Block> blocks, Dictionary<string, Block> blockMap) {
 			this.Blocks = blocks;
 			this.Text = string.Empty;
 			this.Lines = new List<Line>();
@@ -91,7 +91,7 @@ namespace Amazon.Textract.Model {
 			var result = new List<string>();
 			result.Add(string.Format("Page{0}===={0}", Environment.NewLine));
 			this.Content.ForEach(c => {
-				result.Add(string.Format("{1}{0}", Environment.NewLine, c));
+				result.Add($"{Environment.NewLine}{c}");
 			});
 			return string.Join("", result);
 		}

--- a/src-csharp/TextractExtensions/Page.cs
+++ b/src-csharp/TextractExtensions/Page.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using Amazon.Textract.Model;
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 
 	public class Page {
 		public Page(List<Block> blocks, Dictionary<string, Block> blockMap) {

--- a/src-csharp/TextractExtensions/Row.cs
+++ b/src-csharp/TextractExtensions/Row.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 	public class Row {
 		public Row() {
 			this.Cells = new List<Cell>();

--- a/src-csharp/TextractExtensions/Row.cs
+++ b/src-csharp/TextractExtensions/Row.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Amazon.Textract.Model {
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 	public class Row {
 		public Row() {
 			this.Cells = new List<Cell>();

--- a/src-csharp/TextractExtensions/SelectionElement.cs
+++ b/src-csharp/TextractExtensions/SelectionElement.cs
@@ -24,10 +24,11 @@ class SelectionElement:
  */
 
 using System.Collections.Generic;
+using Amazon.Textract.Model;
 
-namespace Amazon.Textract.Model {
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 	public class SelectionElement {
-		public SelectionElement(Block block, List<Block> blocks) {
+		public SelectionElement(Block block, Dictionary<string, Block> blocks) {
 			this.Confidence = block.Confidence;
 			this.Geometry = block.Geometry;
 			this.Id = block.Id;

--- a/src-csharp/TextractExtensions/SelectionElement.cs
+++ b/src-csharp/TextractExtensions/SelectionElement.cs
@@ -26,7 +26,7 @@ class SelectionElement:
 using System.Collections.Generic;
 using Amazon.Textract.Model;
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 	public class SelectionElement {
 		public SelectionElement(Block block, Dictionary<string, Block> blocks) {
 			this.Confidence = block.Confidence;

--- a/src-csharp/TextractExtensions/Table.cs
+++ b/src-csharp/TextractExtensions/Table.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
+using Amazon.Textract.Model;
 
-namespace Amazon.Textract.Model {
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 	public class Table {
-		public Table(Block block, List<Block> blocks) {
+		public Table(Block block, Dictionary<string, Block> blocks) {
 			this.Block = block;
 			this.Confidence = block.Confidence;
 			this.Geometry = block.Geometry;
@@ -17,7 +18,7 @@ namespace Amazon.Textract.Model {
 				relationships.ForEach(r => {
 					if(r.Type == "CHILD") {
 						r.Ids.ForEach(id => {
-							var cell = new Cell(blocks.Find(b => b.Id == id), blocks);
+							var cell = new Cell(blocks[id], blocks);
 							if(cell.RowIndex > ri) {
 								this.Rows.Add(row);
 								row = new Row();

--- a/src-csharp/TextractExtensions/Table.cs
+++ b/src-csharp/TextractExtensions/Table.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using Amazon.Textract.Model;
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 	public class Table {
 		public Table(Block block, Dictionary<string, Block> blocks) {
 			this.Block = block;

--- a/src-csharp/TextractExtensions/TextractDocument.cs
+++ b/src-csharp/TextractExtensions/TextractDocument.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Amazon.Textract.Model;
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 	public class TextractDocument {
 		private Dictionary<string, Block> blockMap = new Dictionary<string, Block>();
 		private List<List<Block>> documentPages = new List<List<Block>>();

--- a/src-csharp/TextractExtensions/TextractDocument.cs
+++ b/src-csharp/TextractExtensions/TextractDocument.cs
@@ -1,42 +1,47 @@
 ﻿using System.Collections.Generic;
+using Amazon.Textract.Model;
 
-namespace Amazon.Textract.Model {
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 	public class TextractDocument {
-		private List<Block> blockMap = new List<Block>();
-		List<List<Block>> documentPages = new List<List<Block>>();
+		private Dictionary<string, Block> blockMap = new Dictionary<string, Block>();
+		private List<List<Block>> documentPages = new List<List<Block>>();
 
 		public TextractDocument(GetDocumentAnalysisResponse response) {
 			this.Pages = new List<Page>();
 			this.ResponsePages = new List<GetDocumentAnalysisResponse>();
 			this.ResponsePages.Add(response);
-
 			this.ParseDocumentPagesAndBlockMap();
 			this.Parse();
 		}
 
 		private void ParseDocumentPagesAndBlockMap() {
-			List<Block> documentPage = null;
-			this.ResponsePages.ForEach(page => {
+            List<Block> documentPage = null;
+            this.ResponsePages.ForEach(page => {
 				page.Blocks.ForEach(block => {
-					this.blockMap.Add(block);
-
-					if(block.BlockType == "PAGE") {
-						if(documentPage != null) {
+					this.blockMap.Add(block.Id, block);
+					if(block.BlockType == "PAGE") 
+                    {
+                        if (documentPage != null) 
+                        {
 							this.documentPages.Add(documentPage);
 						}
 						documentPage = new List<Block>();
 						documentPage.Add(block);
 					} else {
-						documentPage.Add(block);
-					}
+                        if (documentPage == null)
+                        {
+                            documentPage = new List<Block>();
+                        }
+                        documentPage.Add(block);
+                    }
 				});
 			});
 
-			if(documentPage != null) {
-				this.documentPages.Add(documentPage);
-			}
-
-		}
+            if (documentPage != null)
+            {
+                this.documentPages.Add(documentPage);
+            }
+        }
 
 		private void Parse() {
 			this.documentPages.ForEach(documentPage => {
@@ -46,10 +51,10 @@ namespace Amazon.Textract.Model {
 		}
 
 		public Block GetBlockById(string blockId) {
-			return this.blockMap.Find(x => x.Id == blockId);
+			return this.blockMap[blockId];
 		}
 
-		public List<GetDocumentAnalysisResponse> ResponsePages { get; set; }
+        public List<GetDocumentAnalysisResponse> ResponsePages { get; set; }
 		public List<Page> Pages { get; set; }
 		public List<List<Block>> PageBlocks {
 			get {

--- a/src-csharp/TextractExtensions/Word.cs
+++ b/src-csharp/TextractExtensions/Word.cs
@@ -34,18 +34,21 @@ class Word:
  */
 
 using System.Collections.Generic;
+using Amazon.Textract.Model;
 
-namespace Amazon.Textract.Model {
+namespace Flyers.Costing.TextractApi.TextractExtensions {
 	public class Word {
-		public Word(Block block, List<Block> blocks) {
-			this.Block = block;
-			this.Confidence = block.Confidence;
-			this.Geometry = block.Geometry;
-			this.Id = block.Id;
+		public Word(Block block, Dictionary<string, Block> blocks) {
+			this.Block = block ?? new Block();
+			this.Blocks = blocks ?? new Dictionary<string, Block>();
+			this.Confidence = block == null ? 0 : block.Confidence;
+			this.Geometry = block == null ? new Geometry() : block.Geometry;
+            this.Id = block == null ? string.Empty : block.Id;
 			this.Text = block == null ? string.Empty : block.Text;
 		}
 
 		public Block Block { get; set; }
+		public Dictionary<string, Block> Blocks { get; set; }
 		public float Confidence { get; set; }
 		public Geometry Geometry { get; set; }
 		public string Id { get; set; }

--- a/src-csharp/TextractExtensions/Word.cs
+++ b/src-csharp/TextractExtensions/Word.cs
@@ -36,7 +36,7 @@ class Word:
 using System.Collections.Generic;
 using Amazon.Textract.Model;
 
-namespace Flyers.Costing.TextractApi.TextractExtensions {
+namespace Amazon.Textract.Model {
 	public class Word {
 		public Word(Block block, Dictionary<string, Block> blocks) {
 			this.Block = block ?? new Block();


### PR DESCRIPTION
…e a lot of time (for the example PDFs that we've had, it took hours on decent machines).

Cause
- blocks.Find is extremely slow and it is all over the place in the code.

Solution
- Instead of having blocks as a list, I turned into dictionary and having lookups which perform much faster.

Results
- Our document took about 2h to process. This time is reduced now to approx 1s (the same CPU).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
