### PR TITLE
Use local files instead of S3 for most Python examples

### DIFF
--- a/python/03-reading-order.py
+++ b/python/03-reading-order.py
@@ -1,20 +1,18 @@
 import boto3
 
 # Document
-s3BucketName = "ki-textract-demo-docs"
 documentName = "two-column-image.jpg"
 
 # Amazon Textract client
 textract = boto3.client('textract')
 
 # Call Amazon Textract
-response = textract.detect_document_text(
-    Document={
-        'S3Object': {
-            'Bucket': s3BucketName,
-            'Name': documentName
+with open(documentName, "rb") as document:
+    response = textract.detect_document_text(
+        Document={
+            'Bytes': document.read(),
         }
-    })
+    )
 
 #print(response)
 

--- a/python/04-nlp-comprehend.py
+++ b/python/04-nlp-comprehend.py
@@ -1,20 +1,18 @@
 import boto3
 
 # Document
-s3BucketName = "ki-textract-demo-docs"
 documentName = "simple-document-image.jpg"
 
 # Amazon Textract client
 textract = boto3.client('textract')
 
 # Call Amazon Textract
-response = textract.detect_document_text(
-    Document={
-        'S3Object': {
-            'Bucket': s3BucketName,
-            'Name': documentName
+with open(documentName, "rb") as document:
+    response = textract.detect_document_text(
+        Document={
+            'Bytes': document.read(),
         }
-    })
+    )
 
 #print(response)
 

--- a/python/05-nlp-medical.py
+++ b/python/05-nlp-medical.py
@@ -1,20 +1,18 @@
 import boto3
 
 # Document
-s3BucketName = "ki-textract-demo-docs"
 documentName = "medical-notes.png"
 
 # Amazon Textract client
 textract = boto3.client('textract')
 
 # Call Amazon Textract
-response = textract.detect_document_text(
-    Document={
-        'S3Object': {
-            'Bucket': s3BucketName,
-            'Name': documentName
+with open(documentName, "rb") as document:
+    response = textract.detect_document_text(
+        Document={
+            'Bytes': document.read(),
         }
-    })
+    )
 
 #print(response)
 
@@ -41,4 +39,3 @@ for entity in entities["Entities"]:
         for trait in entity["Traits"]:
             print ("    - {}".format(trait["Name"]))
     print("\n")
-    

--- a/python/06-translate.py
+++ b/python/06-translate.py
@@ -1,20 +1,18 @@
 import boto3
 
 # Document
-s3BucketName = "ki-textract-demo-docs"
 documentName = "simple-document-image.jpg"
 
 # Amazon Textract client
 textract = boto3.client('textract')
 
 # Call Amazon Textract
-response = textract.detect_document_text(
-    Document={
-        'S3Object': {
-            'Bucket': s3BucketName,
-            'Name': documentName
+with open(documentName, "rb") as document:
+    response = textract.detect_document_text(
+        Document={
+            'Bytes': document.read(),
         }
-    })
+    )
 
 #print(response)
 

--- a/python/08-forms.py
+++ b/python/08-forms.py
@@ -2,21 +2,18 @@ import boto3
 from trp import Document
 
 # Document
-s3BucketName = "ki-textract-demo-docs"
 documentName = "employmentapp.png"
 
 # Amazon Textract client
 textract = boto3.client('textract')
 
 # Call Amazon Textract
-response = textract.analyze_document(
-    Document={
-        'S3Object': {
-            'Bucket': s3BucketName,
-            'Name': documentName
-        }
-    },
-    FeatureTypes=["FORMS"])
+with open(documentName, "rb") as document:
+    response = textract.analyze_document(
+        Document={
+            'Bytes': document.read(),
+        },
+        FeatureTypes=["FORMS"])
 
 #print(response)
 

--- a/python/09-forms-redaction.py
+++ b/python/09-forms-redaction.py
@@ -3,21 +3,18 @@ from trp import Document
 from PIL import Image, ImageDraw
 
 # Document
-s3BucketName = "ki-textract-demo-docs"
 documentName = "employmentapp.png"
 
 # Amazon Textract client
 textract = boto3.client('textract')
 
 # Call Amazon Textract
-response = textract.analyze_document(
-    Document={
-        'S3Object': {
-            'Bucket': s3BucketName,
-            'Name': documentName
-        }
-    },
-    FeatureTypes=["FORMS"])
+with open(documentName, "rb") as document:
+    response = textract.analyze_document(
+        Document={
+            'Bytes': document.read(),
+        },
+        FeatureTypes=["FORMS"])
 
 #print(response)
 

--- a/python/10-tables.py
+++ b/python/10-tables.py
@@ -2,21 +2,18 @@ import boto3
 from trp import Document
 
 # Document
-s3BucketName = "ki-textract-demo-docs"
 documentName = "employmentapp.png"
 
 # Amazon Textract client
 textract = boto3.client('textract')
 
 # Call Amazon Textract
-response = textract.analyze_document(
-    Document={
-        'S3Object': {
-            'Bucket': s3BucketName,
-            'Name': documentName
-        }
-    },
-    FeatureTypes=["TABLES"])
+with open(documentName, "rb") as document:
+    response = textract.analyze_document(
+        Document={
+            'Bytes': document.read(),
+        },
+        FeatureTypes=["TABLES"])
 
 #print(response)
 

--- a/python/11-tables-expense.py
+++ b/python/11-tables-expense.py
@@ -2,21 +2,18 @@ import boto3
 from trp import Document
 
 # Document
-s3BucketName = "ki-textract-demo-docs"
 documentName = "expense.png"
 
 # Amazon Textract client
 textract = boto3.client('textract')
 
 # Call Amazon Textract
-response = textract.analyze_document(
-    Document={
-        'S3Object': {
-            'Bucket': s3BucketName,
-            'Name': documentName
-        }
-    },
-    FeatureTypes=["TABLES"])
+with open(documentName, "rb") as document:
+    response = textract.analyze_document(
+        Document={
+            'Bytes': document.read(),
+        },
+        FeatureTypes=["TABLES"])
 
 #print(response)
 


### PR DESCRIPTION
Change the Python examples to work with the local files instead of referring the "ki-textract-demo-docs" S3 bucket. This will make it easy for people do simply clone the repo and run the examples without having to worry about creating S3 buckets, uploading files, changing the locations, etc.

ElasticSearch, PDF async and S3 examples still use S3.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
