### PR TITLE
Support broken blocks relations

### DIFF
--- a/python/trp.py
+++ b/python/trp.py
@@ -116,6 +116,8 @@ class Line:
             for rs in block['Relationships']:
                 if(rs['Type'] == 'CHILD'):
                     for cid in rs['Ids']:
+                        if cid not in blockMap:
+                            continue
                         if(blockMap[cid]["BlockType"] == "WORD"):
                             self._words.append(Word(blockMap[cid], blockMap))
     def __str__(self):
@@ -621,7 +623,8 @@ class Document:
                     documentPage = []
                     documentPage.append(block)
                 else:
-                    documentPage.append(block)
+                    if documentPage is not None:
+                        documentPage.append(block)
         if(documentPage):
             documentPages.append({"Blocks" : documentPage})
         return documentPages, blockMap


### PR DESCRIPTION
Description of changes:

When getting more blocks than the "MaxResults" parameter, the parsing of the document fails.
Therefore the parse must be able to support broken references

Closes #16
Issue #16 