### PR TITLE
Fix trp lib

### DIFF
--- a/python/Textract-Table-Merged-Cells-And-Headers.ipynb
+++ b/python/Textract-Table-Merged-Cells-And-Headers.ipynb
@@ -30,8 +30,7 @@
    "source": [
     "!pip install boto3\n",
     "!pip install amazon-textract-caller\n",
-    "!pip install amazon-textract-prettyprinter\n",
-    "!pip install textract-trp"
+    "!pip install amazon-textract-prettyprinter"
    ]
   },
   {
@@ -119,7 +118,7 @@
     "for page in trp_doc.pages:\n",
     "    for table in page.tables:\n",
     "        table_data = []\n",
-    "        headers = table.get_header_field_names()\n",
+    "        headers = []\n",
     "        if(len(headers)>0):                                      #Let's retain the only table with headers\n",
     "            print(\"Statememt headers: \"+ repr(headers))\n",
     "            top_header= headers[0]\n",


### PR DESCRIPTION
*Issue #, if available:*
The trp lib is not supported by Python 3 due to the breaking change in print.
The first solution was to update to pypi's textract-trp.
This caused other issues with missing functions.


*Description of changes:*
Removing the trp library from the install was the ideal resolution as it is already covered.
This has been tested and verified in a blank Jupyter Notebook from Sagemaker.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
