### PR TITLE
Fix validation sample

### DIFF
--- a/python/Textract.ipynb
+++ b/python/Textract.ipynb
@@ -1721,7 +1721,8 @@
     "                    itemName = cell.text\n",
     "                elif(c == 4 and isFloat(cell.text)):\n",
     "                    value = float(cell.text)\n",
-    "                    if(value > 1000):\n",
+    "                    is_summary_row = (r == len(table.rows) - 1)\n",
+    "                    if value > 1000 and not is_summary_row:\n",
     "                        warning += \"{} is greater than $1000.\".format(itemName)\n",
     "if(warning):\n",
     "    print(\"\\nReview needed:\\n====================\\n\" + warning)"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Bug in the the validation sample - it processes the summary line as validation error instead of skipping it.

Fixed output: ```Furniture (Desks and Chairs)  is greater than $1000.```

Current output: ```Furniture (Desks and Chairs)  is greater than $1000. is greater than $1000.```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
